### PR TITLE
auto download

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include ovos-stt-plugin-scribosermo *
+recursive-include ovos_stt_plugin_scribosermo *


### PR DESCRIPTION
- add more LOGs
- auto download ds_scorer to a XDG directory if not set
- auto download model to a XDG directory if not set
- fix MANIFEST.in

TODO
- mirror models in a github release and update urls
- auto download models per language, only english supported


```
2022-01-05 13:11:23.421 - OVOS - mycroft.client.speech.service:on_ready:32 - INFO - Speech client is ready.
2022-01-05 13:11:23.451 - OVOS - neon_stt_plugin_scribosermo:download_checkpoint:88 - INFO - Downloading checkpoint: en_model_quantized.tflite
2022-01-05 13:11:25.331 - OVOS - neon_stt_plugin_scribosermo:download_checkpoint:92 - DEBUG - checkpoint downloaded: /home/user/.local/share/ScriboSermoSTT/en_model_quantized.tflite
2022-01-05 13:11:25.331 - OVOS - neon_stt_plugin_scribosermo:download_scorer:70 - INFO - Downloading deepspeech-0.9.3-models.scorer
2022-01-05 13:12:37.176 - OVOS - neon_stt_plugin_scribosermo:download_scorer:74 - DEBUG - scorer downloaded: /home/user/.local/share/ScriboSermoSTT/deepspeech-0.9.3-models.scorer
2022-01-05 13:12:37.180 - OVOS - neon_stt_plugin_scribosermo:__init__:55 - INFO - Scribosermo STT plugin loaded - model: /home/user/.local/share/ScriboSermoSTT/en_model_quantized.tflite
2022-01-05 13:12:39.185 - OVOS - mycroft.client.speech.mic:listen:861 - DEBUG - Waiting for wake word...
```